### PR TITLE
Keep right/bottom space on cMax and fix crash on certain buttons

### DIFF
--- a/src/fidget.nim
+++ b/src/fidget.nim
@@ -363,7 +363,8 @@ proc constraints*(vCon: Contraints, hCon: Contraints) =
   case vCon
     of cMin: discard
     of cMax:
-      current.box.x = parent.box.w - current.box.w
+      let righSpace = parent.orgbox.w - current.box.x
+      current.box.x = parent.box.w - righSpace
     of cScale:
       let xScale = parent.box.w / parent.orgBox.w
       current.box.x *= xScale
@@ -377,7 +378,8 @@ proc constraints*(vCon: Contraints, hCon: Contraints) =
   case hCon
     of cMin: discard
     of cMax:
-      current.box.y = parent.box.h - current.box.h
+      let bottomSpace = parent.orgbox.h - current.box.y
+      current.box.y = parent.box.h - bottomSpace
     of cScale:
       let yScale = parent.box.h / parent.orgBox.h
       current.box.y *= yScale

--- a/src/fidget/openglbackend/base.nim
+++ b/src/fidget/openglbackend/base.nim
@@ -267,7 +267,7 @@ proc start*() =
             textBox.selectAll()
         else:
           discard
-    elif key < buttonDown.len:
+    elif key < buttonDown.len and key >= 0:
       if buttonDown[key] == false and setKey:
         buttonToggle[key] = not buttonToggle[key]
         buttonPress[key] = true


### PR DESCRIPTION
I had a crash when pressing my dim-screen button because ```key``` was a negative number.
I think those keys can be ignored because they are used to control the OS/DE and not the application.

If the cMax constraints try to replicate what the right constraints in figma do, they should keep the space on the right/bottom size of elements.