### PR TITLE
fix shader paths

### DIFF
--- a/src/fidget/opengl/shaders.nim
+++ b/src/fidget/opengl/shaders.nim
@@ -1,4 +1,4 @@
-import buffers, opengl, os, strformat, strutils, vmath
+import buffers, opengl, os, strformat, strutils, vmath, macros
 
 type
   ShaderAttrib = object
@@ -216,7 +216,7 @@ template newShaderStatic*(computePath: string): Shader =
   ## so it is compiled into the binary.
   const
     computeCode = staticRead(computePath)
-    dir = currentSourcePath().parentDir()
+    dir = getProjectPath()
     computePathFull = dir / computePath
   newShader((computePathFull, computeCode))
 
@@ -241,7 +241,7 @@ template newShaderStatic*(vertPath, fragPath: string): Shader =
   const
     vertCode = staticRead(vertPath)
     fragCode = staticRead(fragPath)
-    dir = currentSourcePath().parentDir()
+    dir = getProjectPath()
     vertPathFull = dir / vertPath
     fragPathFull = dir / fragPath
   newShader((vertPathFull, vertCode), (fragPathFull, fragCode))


### PR DESCRIPTION
currentSourcePath() is returning the path to fidget/opengl/shaders.nim now instead of the file that is calling the template. getProjectPath() gives correct clickable paths.