### PR TITLE
Make async polling agnostic to HttpCall

### DIFF
--- a/src/fidget/openglbackend.nim
+++ b/src/fidget/openglbackend.nim
@@ -366,12 +366,7 @@ proc setupFidget(
 
 proc asyncPoll() =
   when not defined(emscripten) and not defined(fidgetNoAsync):
-    var haveCalls = false
-    for call in httpCalls.values:
-      if call.status == Loading:
-        haveCalls = true
-        break
-    if haveCalls:
+    if hasPendingOperations():
       poll()
 
 proc startFidget*(


### PR DESCRIPTION
This change makes it possible to use other async events, e.g. callbacks, timers, sockets. I have tested it with the hacker news example to make sure the behaviour of `httpGet` is still the same.