### PR TITLE
Fix compilation

### DIFF
--- a/src/fidget/openglbackend.nim
+++ b/src/fidget/openglbackend.nim
@@ -78,7 +78,7 @@ proc unFocus*(keyboard: Keyboard, node: Node) =
     keyboard.focusNode = nil
 
 proc drawText(node: Node) =
-  if node.textStyle.fontFamily notin fonts:
+  if node.textStyle.fontFamily notin common.fonts:
     quit &"font not found: {node.textStyle.fontFamily}"
 
   var font = fonts[node.textStyle.fontFamily]


### PR DESCRIPTION
This commit fixes this compilation error when trying to compile one of
the tests: tests/httpget:

    src/fidget/openglbackend.nim(81, 38) Error: ambiguous identifier: 'fonts' -- use one of the following:
      common.fonts: Table[system.string, font.Font]
      @m..@s..@s..@s..@s..@s.nimble@spkgs@spixie-1.2.0@spixie@sfonts.nim.fonts:

Fixes https://github.com/treeform/fidget/issues/153 .