### PR TITLE
fix text input lineheight

### DIFF
--- a/src/fidget.nim
+++ b/src/fidget.nim
@@ -224,7 +224,7 @@ proc font*(
   current.textStyle.fontFamily = fontFamily
   current.textStyle.fontSize = fontSize
   current.textStyle.fontWeight = fontWeight
-  current.textStyle.lineHeight = lineHeight
+  current.textStyle.lineHeight = if lineHeight != 0.0: lineHeight else: fontSize
   current.textStyle.textAlignHorizontal = textAlignHorizontal
   current.textStyle.textAlignVertical = textAlignVertical
 


### PR DESCRIPTION
The font input is offset because `lineHeight` isn't set on the `input: box` used for input. This fixes that and maybe other issues. 