### PR TITLE
[codex] migrate ci to nimby

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,31 +1,27 @@
-name: Run tests
-on: [push, pull_request]
+name: Github Actions
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
 jobs:
   build:
-    runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
-
-    - name: Cache choosenim
-      id: cache-choosenim
-      uses: actions/cache@v1
-      with:
-        path: ~/.choosenim
-        key: ${{ runner.os }}-choosenim-stable
-
-    - name: Cache nimble
-      id: cache-nimble
-      uses: actions/cache@v1
-      with:
-        path: ~/.nimble
-        key: ${{ runner.os }}-nimble-stable
-
-    - uses: jiro4989/setup-nim-action@v1
-
-    - name: Install GUI
-      run: |
-        sudo apt update
-        sudo apt install -y  build-essential libalut-dev libasound2-dev libc6-dev libgl1-mesa-dev libglu1-mesa-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev libxxf86vm-dev mesa-utils pkg-config xorg-dev xvfb
-    - run: nimble install -y
-    - run: nim c -r tests/run.nim --compile --native --js
+      - uses: actions/checkout@v5
+      - uses: treeform/setup-nim-action@v6
+      - name: Install dependencies
+        shell: bash
+        run: |
+          cd ..
+          nimby install -g "${{ github.event.repository.name }}/${{ github.event.repository.name }}.nimble"
+      - name: Install GUI
+        run: |
+          sudo apt update
+          sudo apt install -y build-essential libalut-dev libasound2-dev libc6-dev libgl1-mesa-dev libglu1-mesa-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev libxxf86vm-dev mesa-utils pkg-config xorg-dev xvfb
+      - run: nim r tests/tests.nim

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: docs
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+permissions:
+  contents: write
+env:
+  nim-src: src/${{ github.event.repository.name }}.nim
+  deploy-dir: .gh-pages
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: treeform/setup-nim-action@v6
+      - name: Install dependencies
+        shell: bash
+        run: |
+          cd ..
+          nimby install -g "${{ github.event.repository.name }}/${{ github.event.repository.name }}.nimble"
+      - run: nim doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
+      - name: "Copy to index.html"
+        run: cp ${{ env.deploy-dir }}/${{ github.event.repository.name }}.html ${{ env.deploy-dir }}/index.html
+      - name: Deploy documents
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ${{ env.deploy-dir }}

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1,0 +1,6 @@
+import os
+
+let command = "nim c -r tests/run.nim --compile --native --js"
+echo command
+if execShellCmd(command) != 0:
+  quit "tests failed"


### PR DESCRIPTION
## Summary
- Replace the legacy CI setup with actions/checkout@v5, treeform/setup-nim-action@v6, and Nimby dependency installation from the GitHub workspace parent.
- Add the docs workflow using the required Nim doc command and gh-pages publishing.
- Add tests/tests.nim as the standard CI entrypoint while preserving the existing Fidget native/JS test runner.

Fidget stays on ubuntu-latest because the existing test workflow depends on Linux GUI/OpenGL packages.

## Validation
- nimby install -g "fidget/fidget.nimble" from C:\p
- nim r tests/tests.nim
- nim doc --index:on --project --git.url:https://github.com/treeform/fidget --git.commit:master  --out:.gh-pages src/fidget.nim
- git diff --check
- git diff --cached --check
